### PR TITLE
Fix link to English version

### DIFF
--- a/content/welcome.article
+++ b/content/welcome.article
@@ -43,7 +43,7 @@ http://golang.org
 
 Тур доступний іншими мовами:
 
-- [[http://http://tour.golang.org/][Англійська — English]]
+- [[http://tour.golang.org/][Англійська — English]]
 - [[http://go-tour-br.appspot.com/][Бразильська португальська — Português do Brasil]]
 - [[http://go-tour-ca.appspot.com/][Каталонська — Català]]
 - [[http://go-tour-de.appspot.com/][Німецька — Deutsch]]


### PR DESCRIPTION
There's an extra http:// on the URL

Fixes golang/go#12075
